### PR TITLE
chore: restructure exports and restore changelog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ import { v3 } from '@phr3nzy/rulekit';
 const { TypedRuleEngine } = v3;
 
 // After
-import { TypedRuleEngine } from '@phr3nzy/rulekit';
+import { RuleEngine } from '@phr3nzy/rulekit';
 ```
 
 Legacy v2 functionality remains available through the v2 namespace:
@@ -68,7 +68,7 @@ const { RuleEngine } = v2.ruleEngine;
 
 ### Breaking Changes
 
-- New v3 API uses different import path (`import { v3 } from '@phr3nzy/rulekit'`)
+- New v3 API is now available at root level
 - Type-safe schemas require explicit type definitions
 - Array conditions now support both element and array-level matching
 - Rule evaluation now validates against schema types
@@ -89,15 +89,14 @@ const { RuleEngine } = v2.ruleEngine;
 import { RuleEngine } from '@phr3nzy/rulekit';
 
 // After (v3)
-import { v3 } from '@phr3nzy/rulekit';
-const { TypedRuleEngine } = v3;
+import { RuleEngine, AttributeType } from '@phr3nzy/rulekit';
 ```
 
 #### 2. Define Type-Safe Schema
 
 ```typescript
-import { v3 } from '@phr3nzy/rulekit';
-const { AttributeType } = v3;
+import { AttributeType } from '@phr3nzy/rulekit';
+import type { AttributeSchema } from '@phr3nzy/rulekit';
 
 // Define your schema with type safety
 type ProductSchema = {
@@ -117,7 +116,7 @@ type ProductSchema = {
 			min: 0;
 		};
 	};
-} & v3.AttributeSchema;
+} & AttributeSchema;
 ```
 
 #### 3. Create Type-Safe Engine
@@ -144,14 +143,14 @@ const productSchema: ProductSchema = {
 };
 
 // Create type-safe engine
-const engine = new TypedRuleEngine(productSchema);
+const engine = new RuleEngine(productSchema);
 ```
 
 #### 4. Use Type-Safe Rules
 
 ```typescript
 // Rules are now type-checked
-const rules: v3.TypedRule<ProductSchema>[] = [
+const rules: Rule<ProductSchema>[] = [
 	{
 		attributes: {
 			category: { eq: 'electronics' }, // Type-safe: must be one of the enum values
@@ -161,7 +160,7 @@ const rules: v3.TypedRule<ProductSchema>[] = [
 ];
 
 // Entities are type-checked
-const entities: v3.TypedEntity<ProductSchema>[] = [
+const entities: Entity<ProductSchema>[] = [
 	{
 		id: '1',
 		name: 'Laptop',
@@ -200,14 +199,15 @@ const rule2 = {
 
 ### Backward Compatibility
 
-V2 exports are still available for backward compatibility:
+V2 exports are still available through the v2 namespace:
 
 ```typescript
-// V2 imports still work
+// Before
 import { RuleEngine } from '@phr3nzy/rulekit';
 
-// V3 recommended imports
-import { v3 } from '@phr3nzy/rulekit';
+// After
+import { v2 } from '@phr3nzy/rulekit';
+const { RuleEngine } = v2.ruleEngine;
 ```
 
 ## [2.0.2] - 2025-02-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - v2 functionality moved to `v2` namespace
   - Better organization of legacy exports
   - Enhanced type safety and import experience
+- Minimum node version is now 18
 
 ### Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [3.0.0] - 2025-02-08
 
 ### Added
@@ -163,6 +168,70 @@ import { RuleEngine } from '@phr3nzy/rulekit';
 import { v3 } from '@phr3nzy/rulekit';
 ```
 
-## Previous Versions
+## [2.0.2] - 2025-02-08
 
-[Previous changelog entries remain unchanged]
+### Improved
+
+- Enhanced documentation:
+  - Updated performance metrics and benchmarks
+  - Improved code examples to reflect synchronous API
+  - Added detailed performance section
+  - Enhanced contributing guidelines
+  - Added CI/CD pipeline details
+  - Updated feature list to highlight performance
+  - Added recommended installation method (pnpm)
+
+## [2.0.1] - 2025-02-08
+
+### Improved
+
+- Enhanced CI/CD pipeline:
+  - Added comprehensive caching for faster builds:
+    - pnpm store caching for dependencies
+    - Coverage report caching
+    - Build output caching
+  - Improved workflow organization:
+    - Separated test and publish jobs
+    - Added proper job dependencies
+    - Enhanced concurrency handling
+  - Added Codecov integration:
+    - Detailed coverage reporting
+    - Coverage upload with proper configuration
+    - Fail CI on coverage regression
+
+## [2.0.0] - 2025-02-07
+
+### Changed
+
+- **BREAKING**: Converted all operations to synchronous for major performance improvements:
+
+  - Removed async/await from all methods
+  - Optimized rule evaluation engine
+  - Improved batch processing performance
+  - Updated all method signatures to be synchronous
+  - Simplified internal implementations
+
+- Performance optimizations:
+  - Pre-allocated result arrays
+  - Removed unnecessary object creation
+  - Optimized Set usage for O(1) lookups
+  - Smart batch size management based on rule complexity
+  - Fast paths for common operations (eq numeric comparisons)
+  - Optimized operator validation with static Set
+
+### Improved
+
+- Test coverage improvements:
+  - Added comprehensive edge case testing
+  - Improved error handling coverage
+  - Added legacy rule validation tests
+  - Expanded numeric conversion tests
+  - Added null value handling tests
+
+### Performance
+
+- Benchmark results:
+  - Real-world entity matching (100 entities): 54102 ops/sec
+  - Complex nested rules (1000 entities): 2276 ops/sec
+  - Large dataset processing (10000 entities): 247 ops/sec
+  - Matching with multiple entities: 2392 ops/sec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2025-02-16
+
+### Changed
+
+- Restructured exports to make v3 the main API:
+  - v3 functionality now available at root level
+  - v2 functionality moved to `v2` namespace
+  - Better organization of legacy exports
+  - Enhanced type safety and import experience
+
+### Improved
+
+- Enhanced project organization:
+  - Cleaner export structure
+  - Better namespace organization
+  - Restored complete changelog history
+  - Improved test file organization
+
+### Migration Note
+
+The v3 API is now available directly from the root:
+
+```typescript
+// Before
+import { v3 } from '@phr3nzy/rulekit';
+const { TypedRuleEngine } = v3;
+
+// After
+import { TypedRuleEngine } from '@phr3nzy/rulekit';
+```
+
+Legacy v2 functionality remains available through the v2 namespace:
+
+```typescript
+// Before
+import { RuleEngine } from '@phr3nzy/rulekit';
+
+// After
+import { v2 } from '@phr3nzy/rulekit';
+const { RuleEngine } = v2.ruleEngine;
+```
+
 ## [3.0.0] - 2025-02-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ pnpm add @phr3nzy/rulekit
 ## Quick Start (v3)
 
 ```typescript
-import { v3 } from '@phr3nzy/rulekit';
-const { AttributeType, TypedRuleEngine } = v3;
+import { AttributeType, RuleEngine } from '@phr3nzy/rulekit';
 
 // 1. Define your schema
 type ProductSchema = {
@@ -59,7 +58,7 @@ type ProductSchema = {
 			required: false;
 		};
 	};
-} & v3.AttributeSchema;
+} & AttributeSchema;
 
 // 2. Create schema instance
 const productSchema: ProductSchema = {
@@ -90,10 +89,10 @@ const productSchema: ProductSchema = {
 };
 
 // 3. Create engine
-const engine = new TypedRuleEngine(productSchema);
+const engine = new RuleEngine(productSchema);
 
 // 4. Define entities
-const entities: v3.TypedEntity<ProductSchema>[] = [
+const entities: Entity<ProductSchema>[] = [
 	{
 		id: '1',
 		name: 'Gaming Laptop',
@@ -117,7 +116,7 @@ const entities: v3.TypedEntity<ProductSchema>[] = [
 ];
 
 // 5. Define rules
-const rules: v3.TypedRule<ProductSchema>[] = [
+const rules: Rule<ProductSchema>[] = [
 	{
 		and: [
 			{
@@ -145,32 +144,32 @@ console.log(matches); // [{ id: '1', name: 'Gaming Laptop', ... }]
 ### Type-Safe Schema Definition
 
 ```typescript
-import { v3 } from '@phr3nzy/rulekit';
+import { AttributeType } from '@phr3nzy/rulekit';
 
 type UserSchema = {
 	role: {
-		type: typeof v3.AttributeType.ENUM;
+		type: typeof AttributeType.ENUM;
 		validation: {
-			type: typeof v3.AttributeType.ENUM;
+			type: typeof AttributeType.ENUM;
 			required: true;
 			enum: ['admin', 'user', 'guest'];
 		};
 	};
 	permissions: {
-		type: typeof v3.AttributeType.ARRAY;
+		type: typeof AttributeType.ARRAY;
 		validation: {
-			type: typeof v3.AttributeType.ARRAY;
-			arrayType: typeof v3.AttributeType.STRING;
+			type: typeof AttributeType.ARRAY;
+			arrayType: typeof AttributeType.STRING;
 			required: true;
 		};
 	};
-} & v3.AttributeSchema;
+} & AttributeSchema;
 ```
 
 ### Complex Rule Combinations
 
 ```typescript
-const rules: v3.TypedRule<UserSchema>[] = [
+const rules: Rule<UserSchema>[] = [
 	{
 		or: [
 			{
@@ -216,7 +215,7 @@ const rule2 = {
 
 ```typescript
 // Engine automatically optimizes batch size based on rule complexity
-const engine = new v3.TypedRuleEngine(schema, {
+const engine = new RuleEngine(schema, {
 	maxBatchSize: 1000, // Optional: customize batch size
 });
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/phr3nzy/rulekit#readme",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "keywords": [
     "rule-engine",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phr3nzy/rulekit",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A powerful and flexible toolkit for building rule-based matching and filtering systems",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/core/models/types.test.ts
+++ b/src/core/models/types.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { ProductAttributeRegistry } from '../attributes/registry';
 import { AttributeType } from '../attributes/types';
-import type { Product } from './types';
+import type { Entity } from './types';
+
+// Alias Entity as Product for better semantic meaning in tests
+type Product = Entity;
 
 describe('Product with Dynamic Attributes', () => {
 	let registry: ProductAttributeRegistry;

--- a/src/core/services/rule-engine.bench.ts
+++ b/src/core/services/rule-engine.bench.ts
@@ -1,6 +1,8 @@
 import { bench, describe } from 'vitest';
-import { RuleEngine } from '../../index';
+import { v2 } from '../../index';
 import type { Entity, Rule } from '../models/types';
+
+const { RuleEngine } = v2.ruleEngine;
 
 /**
  * Type-safe product categories for consistent testing

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,40 +1,61 @@
 import { describe, it, expect } from 'vitest';
-import * as pkg from './index';
+import * as v3 from './v3';
+import { v2 } from './index';
+import { ComparisonOperators, type Entity } from './core/models/types';
 
 describe('Package exports', () => {
-	it('should export all required types and classes', () => {
-		expect(pkg).toHaveProperty('RuleEngine');
-		expect(pkg).toHaveProperty('ComparisonOperators');
-		expect(pkg).toHaveProperty('validateRule');
-		expect(pkg).toHaveProperty('validateRuleSet');
-		expect(pkg).toHaveProperty('validateMatchingConfig');
-		expect(pkg).toHaveProperty('RuleValidationError');
-	});
+	describe('v2 (legacy)', () => {
+		it('should export all required types and classes', () => {
+			expect(v2).toHaveProperty('ruleEngine');
+			expect(ComparisonOperators).toBeDefined();
+			expect(v2.validation).toBeDefined();
+		});
 
-	it('should export ComparisonOperators with correct values', () => {
-		expect(pkg.ComparisonOperators).toEqual({
-			eq: 'eq',
-			ne: 'ne',
-			gt: 'gt',
-			gte: 'gte',
-			lt: 'lt',
-			lte: 'lte',
-			in: 'in',
-			notIn: 'notIn',
+		it('should export ComparisonOperators with correct values', () => {
+			expect(ComparisonOperators).toEqual({
+				eq: 'eq',
+				ne: 'ne',
+				gt: 'gt',
+				gte: 'gte',
+				lt: 'lt',
+				lte: 'lte',
+				in: 'in',
+				notIn: 'notIn',
+			});
+		});
+
+		it('should export Entity type with dynamic attributes support', () => {
+			// Type checking test - this will fail compilation if Entity type doesn't support dynamic attributes
+			const validEntity: Entity = {
+				id: '1',
+				name: 'Test Product',
+				attributes: {
+					customField: 'value',
+					numericField: 123,
+					__validated: true,
+				},
+			};
+			expect(validEntity.attributes.__validated).toBe(true);
 		});
 	});
 
-	it('should export Entity type with dynamic attributes support', () => {
-		// Type checking test - this will fail compilation if Entity type doesn't support dynamic attributes
-		const validEntity: pkg.Entity = {
-			id: '1',
-			name: 'Test Product',
-			attributes: {
-				customField: 'value',
-				numericField: 123,
-				__validated: true,
-			},
-		};
-		expect(validEntity.attributes.__validated).toBe(true);
+	describe('v3', () => {
+		it('should export type-safe API', () => {
+			expect(v3.TypedRuleEngine).toBeDefined();
+			expect(v3.AttributeType).toBeDefined();
+		});
+
+		it('should export schema types', () => {
+			expect(v3.TypedComparisonOperators).toEqual({
+				eq: 'eq',
+				ne: 'ne',
+				gt: 'gt',
+				gte: 'gte',
+				lt: 'lt',
+				lte: 'lte',
+				in: 'in',
+				notIn: 'notIn',
+			});
+		});
 	});
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -41,12 +41,12 @@ describe('Package exports', () => {
 
 	describe('v3', () => {
 		it('should export type-safe API', () => {
-			expect(v3.TypedRuleEngine).toBeDefined();
+			expect(v3.RuleEngine).toBeDefined();
 			expect(v3.AttributeType).toBeDefined();
 		});
 
 		it('should export schema types', () => {
-			expect(v3.TypedComparisonOperators).toEqual({
+			expect(v3.ComparisonOperators).toEqual({
 				eq: 'eq',
 				ne: 'ne',
 				gt: 'gt',

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,24 +3,33 @@
  * @packageDocumentation
  */
 
+// Main exports (v3 type-safe API)
+export * from './v3';
+
 // Legacy v2 exports (for backward compatibility)
-export * from './core/models/types';
-export * from './core/models/validation';
-export * from './core/attributes/types';
-export * from './core/attributes/registry';
-export * from './core/attributes/validator';
-export * from './core/evaluators/types';
-export * from './core/evaluators/base-rule-evaluator';
-export * from './core/services/rule-engine';
-export * from './core/ui/types';
-export * from './core/ui/converter';
-export * from './core/ui/example';
+import * as v2Types from './core/models/types';
+import * as v2Validation from './core/models/validation';
+import * as v2AttributeTypes from './core/attributes/types';
+import * as v2AttributeRegistry from './core/attributes/registry';
+import * as v2AttributeValidator from './core/attributes/validator';
+import * as v2EvaluatorTypes from './core/evaluators/types';
+import * as v2RuleEvaluator from './core/evaluators/base-rule-evaluator';
+import * as v2RuleEngine from './core/services/rule-engine';
+import * as v2UiTypes from './core/ui/types';
+import * as v2UiConverter from './core/ui/converter';
+import * as v2UiExample from './core/ui/example';
 
-// v3 exports (new type-safe API)
-export * as v3 from './v3';
-
-// Export v3 as the default export for new users
-import * as v3Export from './v3';
-export default {
-	v3: v3Export,
+// Export v2 as a namespace for legacy users
+export const v2 = {
+	...v2Types,
+	validation: v2Validation,
+	attributeTypes: v2AttributeTypes,
+	attributeRegistry: v2AttributeRegistry,
+	attributeValidator: v2AttributeValidator,
+	evaluatorTypes: v2EvaluatorTypes,
+	ruleEvaluator: v2RuleEvaluator,
+	ruleEngine: v2RuleEngine,
+	uiTypes: v2UiTypes,
+	uiConverter: v2UiConverter,
+	uiExample: v2UiExample,
 };

--- a/src/v3/__tests__/rule-engine.bench.ts
+++ b/src/v3/__tests__/rule-engine.bench.ts
@@ -1,7 +1,7 @@
 import { bench } from 'vitest';
 import { AttributeType } from '../../core/attributes/types';
-import type { TypedEntity } from '../types/schema';
-import { TypedRuleEngine } from '../engine/rule-engine';
+import type { Entity } from '../types/schema';
+import { RuleEngine } from '../engine/rule-engine';
 
 // Test schema definition
 const CATEGORIES = ['electronics', 'furniture', 'clothing'] as const;
@@ -47,7 +47,7 @@ const createProduct = (
 	price: number,
 	inStock: boolean,
 	tags: string[] = [],
-): TypedEntity<typeof productSchema> => ({
+): Entity<typeof productSchema> => ({
 	id,
 	name: `Product ${id}`,
 	attributes: {
@@ -59,10 +59,10 @@ const createProduct = (
 	},
 });
 
-const engine = new TypedRuleEngine(productSchema);
+const engine = new RuleEngine(productSchema);
 
 // Generate test data
-const generateEntities = (count: number): TypedEntity<typeof productSchema>[] => {
+const generateEntities = (count: number): Entity<typeof productSchema>[] => {
 	return Array.from({ length: count }, (_, i) =>
 		createProduct(
 			`${i}`,

--- a/src/v3/__tests__/rule-engine.test.ts
+++ b/src/v3/__tests__/rule-engine.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { AttributeType, type AttributeTypeValue } from '../../core/attributes/types';
-import type { AttributeSchema, TypedEntity } from '../types/schema';
-import { TypedRuleEngine } from '../engine/rule-engine';
+import type { AttributeSchema, Entity } from '../types/schema';
+import { RuleEngine } from '../engine/rule-engine';
 
-describe('TypedRuleEngine', () => {
+describe('RuleEngine', () => {
 	const CATEGORIES = ['electronics', 'furniture', 'clothing'] as const;
 
 	// Test schema definition
@@ -83,7 +83,7 @@ describe('TypedRuleEngine', () => {
 		price: number,
 		inStock: boolean,
 		tags: string[] = [],
-	): TypedEntity<ProductSchema> => ({
+	): Entity<ProductSchema> => ({
 		id,
 		name: `Product ${id}`,
 		attributes: {
@@ -96,7 +96,7 @@ describe('TypedRuleEngine', () => {
 	});
 
 	describe('findMatchingFrom', () => {
-		const engine = new TypedRuleEngine(productSchema);
+		const engine = new RuleEngine(productSchema);
 
 		it('matches entities with simple attribute rules', () => {
 			const entities = [
@@ -201,7 +201,7 @@ describe('TypedRuleEngine', () => {
 						category: 'invalid',
 						__validated: true,
 					},
-				} as TypedEntity<ProductSchema>,
+				} as Entity<ProductSchema>,
 			];
 
 			const rules = [{ attributes: { category: { eq: 'electronics' } } }];
@@ -213,7 +213,7 @@ describe('TypedRuleEngine', () => {
 	});
 
 	describe('findMatchingTo', () => {
-		const engine = new TypedRuleEngine(productSchema);
+		const engine = new RuleEngine(productSchema);
 
 		it('finds matching target entities', () => {
 			const fromEntities = [createProduct('1', 'electronics', 100, true)];


### PR DESCRIPTION
- Make v3 the main export and v2 the legacy export
- Fix test files to use v2 namespace
- Restore pre-v3 changelog history
- Fix type errors in test files